### PR TITLE
document zero values in RX debug messages

### DIFF
--- a/advanced_usage.md
+++ b/advanced_usage.md
@@ -96,7 +96,7 @@ There is a user button on both TX and RX board. Usually they are unused:
 
 For TX, a short press (less than 2 seconds) recalibrates the baseline. A long press (more than 2 seconds) enters Test Mode, where it sends test packets with incrementing sequence number as payload every second. It can be used to test communication range. Turn it off then on again to exit Test Mode. 
 
-For RX, a press on the button types out some debug messages. Make sure you open a text editor first. 
+For RX, a press on the button types out some debug messages. Make sure you open a text editor first. If the RX has not recieved any messages from the TX, the debug values will all be zero.
 
 ## USB Firmware Updates
 


### PR DESCRIPTION
When people see their RX's debug message's values are all zero it can make people think their RX is broken really when it's the TX isn't transmitting.

For reference, this is the "all zero values" situation I mean:

```
transmitter ID: 0x0
baseline: 0mm
latest trigger: 0mm
input voltage: 0mV
power-on time: 0 minutes
```

when seeing that I first thought my RX must be broken, but now I understand that's just how the RX behaves if it's never received anything from the TX.